### PR TITLE
Using fixed thread pool for client creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.github.oinker4577</groupId>
     <artifactId>jedis-mock</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
     <name>jedis-mock</name>
     <description>In memory Redis mock for testing</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.github.oinker4577</groupId>
     <artifactId>jedis-mock</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <packaging>jar</packaging>
     <name>jedis-mock</name>
     <description>In memory Redis mock for testing</description>

--- a/src/main/java/com/github/fang/jedismock/operations/RO_rename.java
+++ b/src/main/java/com/github/fang/jedismock/operations/RO_rename.java
@@ -19,6 +19,7 @@ class RO_rename extends AbstractRedisOperation {
         if (ttl == null) {
             return false;
         }
+        base().deleteValue(newKey);
         for (Map.Entry<Slice, Slice> entry : value.entrySet()) {
             base().putValue(newKey, entry.getKey(), entry.getValue(), ttl);
         }

--- a/src/main/java/com/github/fang/jedismock/server/RedisClient.java
+++ b/src/main/java/com/github/fang/jedismock/server/RedisClient.java
@@ -52,7 +52,7 @@ public class RedisClient implements Runnable {
             Optional<RedisCommand> command = nextCommand();
 
             if(command.isPresent()){
-                LOG.info("command: {}", command.get());
+                LOG.debug("command: {}", command.get());
                 Slice response = executor.execCommand(command.get());
                 sendResponse(response, command.toString());
 
@@ -62,12 +62,11 @@ public class RedisClient implements Runnable {
                 }
             } else {
                 running.set(false);
-//                this.close();
             }
         }
 
         close();
-        LOG.info("Mock redis connection shutting down.");
+        LOG.debug("Mock redis connection shutting down.");
     }
 
     /**

--- a/src/main/java/com/github/fang/jedismock/server/RedisClient.java
+++ b/src/main/java/com/github/fang/jedismock/server/RedisClient.java
@@ -52,6 +52,7 @@ public class RedisClient implements Runnable {
             Optional<RedisCommand> command = nextCommand();
 
             if(command.isPresent()){
+                LOG.info("command: {}", command.get());
                 Slice response = executor.execCommand(command.get());
                 sendResponse(response, command.toString());
 
@@ -59,10 +60,14 @@ public class RedisClient implements Runnable {
                 if (options.autoCloseOn() != 0 && options.autoCloseOn() == count) {
                     break;
                 }
+            } else {
+                running.set(false);
+//                this.close();
             }
         }
 
-        LOG.debug("Mock redis connection shutting down.");
+        close();
+        LOG.info("Mock redis connection shutting down.");
     }
 
     /**

--- a/src/main/java/com/github/fang/jedismock/server/RedisService.java
+++ b/src/main/java/com/github/fang/jedismock/server/RedisService.java
@@ -37,8 +37,6 @@ public class RedisService implements Runnable {
             try {
                 Socket socket = server.accept();
                 socket.setSoTimeout(500);
-//                Thread t = new Thread(new RedisClient(redisBases, socket, options));
-//                t.start();
                 Runnable task = new RedisClient(redisBases, socket, options);
                 executorService.execute(task);
             } catch (IOException e) {

--- a/src/main/java/com/github/fang/jedismock/server/RedisService.java
+++ b/src/main/java/com/github/fang/jedismock/server/RedisService.java
@@ -38,7 +38,7 @@ public class RedisService implements Runnable {
                 Socket socket = server.accept();
                 socket.setSoTimeout(500);
                 Runnable task = new RedisClient(redisBases, socket, options);
-                executorService.execute(task);
+                executorService.submit(task);
             } catch (IOException e) {
                 // Do noting
             }

--- a/src/main/java/com/github/fang/jedismock/server/RedisService.java
+++ b/src/main/java/com/github/fang/jedismock/server/RedisService.java
@@ -38,7 +38,7 @@ public class RedisService implements Runnable {
                 Socket socket = server.accept();
                 socket.setSoTimeout(500);
                 Runnable task = new RedisClient(redisBases, socket, options);
-                executorService.submit(task);
+                executorService.execute(task);
             } catch (IOException e) {
                 // Do noting
             }

--- a/src/main/java/com/github/fang/jedismock/server/RedisService.java
+++ b/src/main/java/com/github/fang/jedismock/server/RedisService.java
@@ -7,12 +7,17 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Created by Xiaolu on 2015/4/21.
  */
 public class RedisService implements Runnable {
 
+    private static final int NUM_THREADS = 10;
+    private static final ExecutorService executorService
+            = Executors.newFixedThreadPool(NUM_THREADS);
     private final ServerSocket server;
     private final Map<Integer, RedisBase> redisBases;
     private final ServiceOptions options;
@@ -31,8 +36,11 @@ public class RedisService implements Runnable {
         while (!server.isClosed()) {
             try {
                 Socket socket = server.accept();
-                Thread t = new Thread(new RedisClient(redisBases, socket, options));
-                t.start();
+                socket.setSoTimeout(500);
+//                Thread t = new Thread(new RedisClient(redisBases, socket, options));
+//                t.start();
+                Runnable task = new RedisClient(redisBases, socket, options);
+                executorService.execute(task);
             } catch (IOException e) {
                 // Do noting
             }

--- a/src/main/java/com/github/fang/jedismock/server/RedisService.java
+++ b/src/main/java/com/github/fang/jedismock/server/RedisService.java
@@ -16,8 +16,6 @@ import java.util.concurrent.ExecutorService;
 public class RedisService implements Runnable {
 
     private static final int NUM_THREADS = 10;
-    private static final ExecutorService executorService
-            = Executors.newFixedThreadPool(NUM_THREADS);
     private final ServerSocket server;
     private final Map<Integer, RedisBase> redisBases;
     private final ServiceOptions options;
@@ -33,6 +31,8 @@ public class RedisService implements Runnable {
     }
 
     public void run() {
+        ExecutorService executorService
+                = Executors.newFixedThreadPool(NUM_THREADS);
         while (!server.isClosed()) {
             try {
                 Socket socket = server.accept();
@@ -43,5 +43,6 @@ public class RedisService implements Runnable {
                 // Do noting
             }
         }
+        executorService.shutdown();
     }
 }

--- a/src/test/java/com/github/fang/jedismock/TestRedisOperationExecutor.java
+++ b/src/test/java/com/github/fang/jedismock/TestRedisOperationExecutor.java
@@ -440,4 +440,14 @@ public class TestRedisOperationExecutor {
         assertCommandNull(array("get", "old"));
     }
 
+    @Test
+    public void testRenameHashWithExistingValues() {
+        assertCommandEquals(1, array("hset", "old", "a", "1"));
+        assertCommandEquals(1, array("hset", "new", "z", "2"));
+        assertCommandOK(array("rename", "old", "new"));
+        assertCommandEquals("1", array("hget", "new", "a"));
+        assertCommandNull(array("hget", "new", "z"));
+        assertCommandNull(array("get", "old"));
+    }
+
 }


### PR DESCRIPTION
For our unit testing we had at one point ~500 created clients and hence ~500 threads all trying to read (blocking) from socket input streams. This was using up a lot of resources, causing testing commands to slow down and timeout. 

This is a temporary fix to use a fixed thread pool (of 10 which is now arbitrary) and setting a timeout on sockets (500ms again arbitrary for now) so that we don't spin up an unlimited amount of threads and don't read indefinitely from socket input streams where commands are not being written to anymore